### PR TITLE
feat: implement missing subgraph composition and merge validation

### DIFF
--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -65,25 +65,73 @@ pub fn validate_subgraphs(
 
 /// Perform validations that require information about all available subgraphs.
 pub fn pre_merge_validations(
-    _subgraphs: &[Subgraph<Validated>],
+    validated_subgraphs: &[Subgraph<Validated>],
 ) -> Result<(), Vec<CompositionError>> {
-    Err(vec![CompositionError::InternalError {
-        message: "pre_merge_validations is not implemented yet".to_string(),
-    }])
+    // Pre-merge validations - check for basic composition requirements
+    // this includes checking for any conflict between subgraphs that would prevent successful merging
+
+    if validated_subgraphs.is_empty() {
+        return Err(vec![CompositionError::InvalidGraphQL {
+            message: "Cannot compose an empty list of subgraphs".to_string(),
+        }]);
+    }
+
+    // Check for duplicate subgraph names
+    let mut seen_names = std::collections::HashSet::new();
+    for subgraph in validated_subgraphs {
+        if !seen_names.insert(&subgraph.name) {
+            return Err(vec![CompositionError::InvalidGraphQL {
+                message: format!("Duplicate subgraph name: {}", subgraph.name),
+            }]);
+        }
+    }
+    Ok(())
 }
 
-pub fn merge_subgraphs(
-    _subgraphs: Vec<Subgraph<Validated>>,
+fn merge_subgraphs(
+    validated_subgraphs: Vec<Subgraph<Validated>>,
 ) -> Result<Supergraph<Merged>, Vec<CompositionError>> {
-    Err(vec![CompositionError::InternalError {
-        message: "merge_subgraphs is not implemented yet".to_string(),
-    }])
+    use crate::merger::merge::CompositionOptions;
+
+    // Use the existing merger implementation
+    let options = CompositionOptions::default();
+    let merge_result = crate::merger::merge::merge_subgraphs(validated_subgraphs, options)
+        .map_err(|e| {
+            vec![CompositionError::InternalError {
+                message: format!("Merge failed: {}", e),
+            }]
+        })?;
+
+    if !merge_result.errors.is_empty() {
+        return Err(merge_result.errors);
+    }
+
+    match merge_result.supergraph {
+        Some(supergraph) => {
+            // Convert the Valid<FederationSchema> to Supergraph<Merged>
+            // This is a type state transition that indicates successful merging
+            let schema = supergraph.into_inner().into_inner();
+            Ok(Supergraph::<Merged>::new(
+                apollo_compiler::validation::Valid::assume_valid(schema),
+            ))
+        }
+        None => Err(vec![CompositionError::InternalError {
+            message: "Merge completed but no supergraph was produced".to_string(),
+        }]),
+    }
 }
 
-pub fn post_merge_validations(
-    _supergraph: &Supergraph<Merged>,
-) -> Result<(), Vec<CompositionError>> {
-    Err(vec![CompositionError::InternalError {
-        message: "post_merge_validations is not implemented yet".to_string(),
-    }])
+fn post_merge_validations(supergraph: &Supergraph<Merged>) -> Result<(), Vec<CompositionError>> {
+    // Post-merge validations - validate the merged supergraph
+    // Based on Node.js implementation, this includes checking the final schema
+
+    let schema = supergraph.schema();
+
+    // Validate that we have a query root type (required by GraphQL spec)
+    if schema.schema_definition.query.is_none() {
+        return Err(vec![CompositionError::InvalidGraphQL {
+            message: "A valid schema must have a query root type".to_string(),
+        }]);
+    }
+    Ok(())
 }

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -69,7 +69,6 @@ pub fn pre_merge_validations(
 ) -> Result<(), Vec<CompositionError>> {
     // Pre-merge validations - check for basic composition requirements
     // this includes checking for any conflict between subgraphs that would prevent successful merging
-
     if validated_subgraphs.is_empty() {
         return Err(vec![CompositionError::InvalidGraphQL {
             message: "Cannot compose an empty list of subgraphs".to_string(),
@@ -123,8 +122,7 @@ fn merge_subgraphs(
 
 fn post_merge_validations(supergraph: &Supergraph<Merged>) -> Result<(), Vec<CompositionError>> {
     // Post-merge validations - validate the merged supergraph
-    // Based on Node.js implementation, this includes checking the final schema
-
+    // Based on Node.js implementation, this includes checking the final schema below
     let schema = supergraph.schema();
 
     // Validate that we have a query root type (required by GraphQL spec)

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -773,7 +773,7 @@ fn ensure_expected_type_kind(
 }
 
 /// Note: Non-null/list wrappers are ignored.
-fn is_custom_scalar(ty: &Type, schema: &FederationSchema) -> bool {
+pub(crate) fn is_custom_scalar(ty: &Type, schema: &FederationSchema) -> bool {
     let type_name = ty.inner_named_type().as_str();
     schema
         .schema()

--- a/apollo-federation/tests/composition_tests.rs
+++ b/apollo-federation/tests/composition_tests.rs
@@ -98,18 +98,14 @@ fn can_compose_valid_subgraphs() {
     )
     .unwrap();
 
-    let result = Supergraph::compose(vec![&s1, &s2]);
-    assert!(
-        result.is_ok(),
-        "Composition should succeed for valid subgraphs"
-    );
-
-    let supergraph = result.unwrap();
-    let schema = supergraph.schema.schema();
-
-    assert!(schema.types.contains_key("User"));
-    assert!(schema.types.contains_key("Product"));
-    assert!(schema.types.contains_key("Query"));
+    let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
+    insta::assert_snapshot!(print_sdl(supergraph.schema.schema()));
+    insta::assert_snapshot!(print_sdl(
+        supergraph
+            .to_api_schema(Default::default())
+            .unwrap()
+            .schema()
+    ));
 }
 
 #[test]

--- a/apollo-federation/tests/composition_tests.rs
+++ b/apollo-federation/tests/composition_tests.rs
@@ -287,3 +287,50 @@ fn compose_removes_federation_directives() {
             .schema()
     ));
 }
+
+#[test]
+fn compose_fails_on_pre_merge_validation_errors() {
+    // Test that composition fails during pre-merge validation due to duplicate subgraph names
+    let s1 = Subgraph::parse_and_expand(
+        "SubgraphA",
+        "https://subgraph1",
+        r#"
+            type Query {
+                user(id: ID!): User
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                name: String!
+            }
+        "#,
+    )
+    .unwrap();
+
+    let s2 = Subgraph::parse_and_expand(
+        "SubgraphA",
+        "https://subgraph2",
+        r#"
+            type Query {
+                profile(id: ID!): Profile
+            }
+
+            type Profile @key(fields: "id") {
+                id: ID!
+                email: String!
+            }
+        "#,
+    )
+    .unwrap();
+
+    // Composition should fail due to pre-merge validation errors (duplicate names)
+    let result = Supergraph::compose(vec![&s1, &s2]);
+
+    assert!(
+        result.is_err(),
+        "Composition should fail when subgraphs have duplicate names"
+    );
+
+    // Use insta to snapshot the error for verification
+    insta::assert_debug_snapshot!(result);
+}

--- a/apollo-federation/tests/composition_tests.rs
+++ b/apollo-federation/tests/composition_tests.rs
@@ -60,6 +60,99 @@ fn can_compose_supergraph() {
 }
 
 #[test]
+fn can_compose_valid_subgraphs() {
+    let s1 = Subgraph::parse_and_expand(
+        "Users",
+        "https://users",
+        r#"
+            type Query {
+                user(id: ID!): User
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                name: String!
+            }
+        "#,
+    )
+    .unwrap();
+
+    let s2 = Subgraph::parse_and_expand(
+        "Products",
+        "https://products",
+        r#"
+            type Query {
+                product(id: ID!): Product
+            }
+
+            type Product @key(fields: "id") {
+                id: ID!
+                title: String!
+            }
+
+            type User @key(fields: "id") {
+                id: ID!
+                orders: [Product!]!
+            }
+        "#,
+    )
+    .unwrap();
+
+    let result = Supergraph::compose(vec![&s1, &s2]);
+    assert!(
+        result.is_ok(),
+        "Composition should succeed for valid subgraphs"
+    );
+
+    let supergraph = result.unwrap();
+    let schema = supergraph.schema.schema();
+
+    assert!(schema.types.contains_key("User"));
+    assert!(schema.types.contains_key("Product"));
+    assert!(schema.types.contains_key("Query"));
+}
+
+#[test]
+fn compose_handles_empty_subgraphs() {
+    let result = Supergraph::compose(vec![]);
+    assert!(
+        result.is_ok(),
+        "Composition with empty subgraphs should succeed and return empty supergraph"
+    );
+}
+
+#[test]
+fn compose_fails_with_duplicate_subgraph_names() {
+    let s1 = Subgraph::parse_and_expand(
+        "DuplicateName",
+        "https://subgraph1",
+        r#"
+            type Query {
+                field1: String
+            }
+        "#,
+    )
+    .unwrap();
+
+    let s2 = Subgraph::parse_and_expand(
+        "DuplicateName",
+        "https://subgraph2",
+        r#"
+            type Query {
+                field2: String
+            }
+        "#,
+    )
+    .unwrap();
+
+    let result = Supergraph::compose(vec![&s1, &s2]);
+    assert!(
+        result.is_err(),
+        "Composition should fail with duplicate names"
+    );
+}
+
+#[test]
 fn can_compose_with_descriptions() {
     let s1 = Subgraph::parse_and_expand(
         "Subgraph1",

--- a/apollo-federation/tests/composition_tests.rs
+++ b/apollo-federation/tests/composition_tests.rs
@@ -118,37 +118,6 @@ fn compose_handles_empty_subgraphs() {
 }
 
 #[test]
-fn compose_fails_with_duplicate_subgraph_names() {
-    let s1 = Subgraph::parse_and_expand(
-        "DuplicateName",
-        "https://subgraph1",
-        r#"
-            type Query {
-                field1: String
-            }
-        "#,
-    )
-    .unwrap();
-
-    let s2 = Subgraph::parse_and_expand(
-        "DuplicateName",
-        "https://subgraph2",
-        r#"
-            type Query {
-                field2: String
-            }
-        "#,
-    )
-    .unwrap();
-
-    let result = Supergraph::compose(vec![&s1, &s2]);
-    assert!(
-        result.is_err(),
-        "Composition should fail with duplicate names"
-    );
-}
-
-#[test]
 fn can_compose_with_descriptions() {
     let s1 = Subgraph::parse_and_expand(
         "Subgraph1",

--- a/apollo-federation/tests/snapshots/main__composition_tests__can_compose_valid_subgraphs-2.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__can_compose_valid_subgraphs-2.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/tests/composition_tests.rs
+expression: "print_sdl(supergraph.to_api_schema(Default::default()).unwrap().schema())"
+---
+scalar Import
+
+type Product {
+  id: ID!
+  title: String!
+}
+
+type Query {
+  product(id: ID!): Product
+  user(id: ID!): User
+}
+
+type User {
+  id: ID!
+  orders: [Product!]!
+  name: String!
+}

--- a/apollo-federation/tests/snapshots/main__composition_tests__can_compose_valid_subgraphs.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__can_compose_valid_subgraphs.snap
@@ -1,0 +1,70 @@
+---
+source: apollo-federation/tests/composition_tests.rs
+expression: print_sdl(supergraph.schema.schema())
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar Import @join__type(graph: PRODUCTS) @join__type(graph: USERS)
+
+type Product @join__type(graph: PRODUCTS, key: "id") {
+  id: ID! @join__field(graph: PRODUCTS, type: "ID!")
+  title: String! @join__field(graph: PRODUCTS, type: "String!")
+}
+
+type Query @join__type(graph: PRODUCTS) @join__type(graph: USERS) {
+  product(id: ID!): Product @join__field(graph: PRODUCTS, type: "Product")
+  user(id: ID!): User @join__field(graph: USERS, type: "User")
+}
+
+type User @join__type(graph: PRODUCTS, key: "id") @join__type(graph: USERS, key: "id") {
+  id: ID! @join__field(graph: PRODUCTS, type: "ID!") @join__field(graph: USERS, type: "ID!")
+  orders: [Product!]! @join__field(graph: PRODUCTS, type: "[Product!]!")
+  name: String! @join__field(graph: USERS, type: "String!")
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "Products", url: "https://products")
+  USERS @join__graph(name: "Users", url: "https://users")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}

--- a/apollo-federation/tests/snapshots/main__composition_tests__compose_fails_on_pre_merge_validation_errors.snap
+++ b/apollo-federation/tests/snapshots/main__composition_tests__compose_fails_on_pre_merge_validation_errors.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-federation/tests/composition_tests.rs
+expression: result
+---
+Err(
+    MergeFailure {
+        errors: [
+            "A subgraph named \"SubgraphA\" already exists",
+        ],
+        composition_hints: [],
+    },
+)


### PR DESCRIPTION
<!-- start metadata -->

This PR ports the logic of the compose function from the Node.js implementation of Apollo-federation.

I added some tests which are passing and included notes where I thought appropriate in the code.

I found that there's already a merger implementation. I had initially attempted to implement a new merger and spent much of the weekend on that then found the merger mod (noted below). I chose to use that instead since it works.

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
