### PR TITLE
implements missing compose components

### DIFF
--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -4,7 +4,10 @@ use std::vec;
 
 pub use crate::composition::satisfiability::validate_satisfiability;
 use crate::error::CompositionError;
+use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
 pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
+use crate::subgraph::ValidSubgraph;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Initial;
 use crate::subgraph::typestate::Subgraph;
@@ -65,25 +68,112 @@ pub fn validate_subgraphs(
 
 /// Perform validations that require information about all available subgraphs.
 pub fn pre_merge_validations(
-    _subgraphs: &[Subgraph<Validated>],
+    subgraphs: &[Subgraph<Validated>],
 ) -> Result<(), Vec<CompositionError>> {
-    Err(vec![CompositionError::InternalError {
-        message: "pre_merge_validations is not implemented yet".to_string(),
-    }])
+    let mut errors: Vec<CompositionError> = vec![];
+
+    for subgraph in subgraphs {
+        if let Err(error) = subgraph.schema().clone().into_inner().validate() {
+            errors.push(CompositionError::InternalError {
+                message: error.to_string(),
+            })
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }
 
 pub fn merge_subgraphs(
-    _subgraphs: Vec<Subgraph<Validated>>,
+    subgraphs: Vec<Subgraph<Validated>>,
 ) -> Result<Supergraph<Merged>, Vec<CompositionError>> {
-    Err(vec![CompositionError::InternalError {
-        message: "merge_subgraphs is not implemented yet".to_string(),
-    }])
+    let mut errors: Vec<CompositionError> = vec![];
+
+    let valid_subgraphs: Vec<ValidSubgraph> =
+        subgraphs.iter().map(|s| s.to_valid_subgraph()).collect();
+
+    crate::merge::merge_subgraphs(valid_subgraphs.iter().collect())
+        .map(|merged| Supergraph::<Merged>::new(merged.schema))
+        .map_err(|e| {
+            errors.push(CompositionError::SubgraphError {
+                subgraph: e.schema.unwrap().to_string(),
+                error: FederationError::MultipleFederationErrors(MultipleFederationErrors {
+                    errors: e
+                        .errors
+                        .iter()
+                        .map(|e| crate::error::SingleFederationError::Internal {
+                            message: e.clone(),
+                        })
+                        .collect(),
+                }),
+            });
+
+            errors
+        })
 }
 
 pub fn post_merge_validations(
-    _supergraph: &Supergraph<Merged>,
+    supergraph: &Supergraph<Merged>,
 ) -> Result<(), Vec<CompositionError>> {
-    Err(vec![CompositionError::InternalError {
-        message: "post_merge_validations is not implemented yet".to_string(),
-    }])
+    let mut errors: Vec<CompositionError> = vec![];
+    supergraph
+        .schema()
+        .clone()
+        .into_inner()
+        .validate()
+        .map(|_| ())
+        .map_err(|error| {
+            errors.push(CompositionError::InternalError {
+                message: error.to_string(),
+            });
+
+            errors
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::subgraph::typestate::Initial;
+
+    // Helper: create a Subgraph<Validated> from SDL by running it through the real pipeline.
+    fn make_validated_subgraph(name: &str, sdl: &str) -> Result<Subgraph<Validated>, String> {
+        // Parse the SDL into a Schema and construct an initial Subgraph with a dummy URL.
+        let schema = apollo_compiler::schema::Schema::parse(sdl, ".").expect("parse SDL to Schema");
+        let initial: Subgraph<Initial> = Subgraph::new(name, "http://localhost", schema);
+        let expanded = expand_subgraphs(vec![initial]).expect("expand links");
+        let upgraded =
+            upgrade_subgraphs_if_necessary(expanded).expect("upgrade subgraphs if necessary");
+        let validated = validate_subgraphs(upgraded).expect("validate subgraphs");
+        Ok(validated
+            .into_iter()
+            .next()
+            .expect("one validated subgraph"))
+    }
+
+    #[test]
+    fn pre_merge_validations_ok_new_first() {
+        let sdl = r#"
+            type Query {
+              hello: String
+            }
+        "#;
+        let validated = make_validated_subgraph("svc1", sdl).expect("invalid subgraph");
+        let result = pre_merge_validations(&[validated.clone()]);
+
+        assert!(result.is_ok());
+
+        let merger_result = merge_subgraphs(vec![validated]);
+
+        assert!(merger_result.is_ok());
+
+        let post_merge_validation = post_merge_validations(&merger_result.as_ref().unwrap());
+
+        assert!(post_merge_validation.is_ok());
+
+        assert!(validate_satisfiability(merger_result.unwrap()).is_ok())
+    }
 }

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -49,6 +49,7 @@ use crate::schema::type_and_directive_specification::ResolvedArgumentSpecificati
 use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecification;
 use crate::schema::type_and_directive_specification::UnionTypeSpecification;
 use crate::subgraph::SubgraphError;
+use crate::subgraph::ValidSubgraph;
 use crate::supergraph::ANY_TYPE_SPEC;
 use crate::supergraph::EMPTY_QUERY_TYPE_SPEC;
 use crate::supergraph::FEDERATION_ANY_TYPE_NAME;
@@ -366,6 +367,14 @@ impl Subgraph<Validated> {
                 schema: (*self.state.schema).clone(),
                 metadata: self.state.metadata,
             },
+        }
+    }
+
+    pub fn to_valid_subgraph(&self) -> ValidSubgraph {
+        ValidSubgraph {
+            name: self.name.clone(),
+            url: self.url.clone(),
+            schema: self.validated_schema().schema().clone(),
         }
     }
 }


### PR DESCRIPTION
<!-- start metadata -->
PR implements unimplemented component functions in compose function. They unclude `pre_merge_validations`, `merge_subgraphs`, `post_merge_validations`. 

The PR also includes unit test testing these functions against `validate_satisfiability`

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
